### PR TITLE
レスポンシブ対応 / テキスト変換対応 / 表示項目追加対応

### DIFF
--- a/components/organisms/ReviewContent.vue
+++ b/components/organisms/ReviewContent.vue
@@ -29,37 +29,37 @@
               <v-card-text>
                 総合：
                 <br />
-                {{ review.general_post }}
+                <p v-html="transformTextToHtml(review.general_post)" />
               </v-card-text>
               <v-card-text>
                 チーム方針：
                 <br />
-                {{ review.policy_post }}
+                <p v-html="transformTextToHtml(review.policy_post)" />
               </v-card-text>
               <v-card-text>
                 チーム体制：
                 <br />
-                {{ review.organization_post }}
+                <p v-html="transformTextToHtml(review.organization_post)" />
               </v-card-text>
               <v-card-text>
                 活動内容：
                 <br />
-                {{ review.activity_post }}
+                <p v-html="transformTextToHtml(review.activity_post)" />
               </v-card-text>
               <v-card-text>
                 チーム環境：
                 <br />
-                {{ review.environment_post }}
+                <p v-html="transformTextToHtml(review.environment_post)" />
               </v-card-text>
               <v-card-text>
                 イベント：
                 <br />
-                {{ review.event_post }}
+                <p v-html="transformTextToHtml(review.event_post)" />
               </v-card-text>
               <v-card-text>
                 費用：
                 <br />
-                {{ review.cost_post }}
+                <p v-html="transformTextToHtml(review.cost_post)" />
               </v-card-text>
             </v-card>
           </v-col>
@@ -70,6 +70,7 @@
 </template>
 
 <script>
+import transformTextToHtml from '~/pages/utils/transformTextToHtml'
 
 export default {
   components: {
@@ -82,6 +83,7 @@ export default {
   },
   data () {
     return {
+      transformTextToHtml,
       genderTypeList: [
         '男性',
         '女性'

--- a/components/organisms/ReviewContent.vue
+++ b/components/organisms/ReviewContent.vue
@@ -11,7 +11,7 @@
             <p>- 在籍年: {{ review.enrollment_period }}</p>
             <p>- あなたの立場: {{ displayIsPlayer }}</p>
 
-            <div class="d-flex justify-left align-center">
+            <div :class="`${!isMobile && 'd-flex justify-left align-center'}`">
               <v-rating v-model="review.general_point" readonly />
 
               <!-- due to comment out unnecessary?? -->
@@ -19,7 +19,7 @@
 
               <div>方針: {{ review.policy_point }}  体制: {{ review.organization_point }}  活動: {{ review.activity_point }}  環境: {{ review.environment_point }}  イベント: {{ review.event_point }}  費用: {{ review.cost_point }}</div>
             </div>
-            <v-card class="d-inline-block mx-auto" min-width="60vw">
+            <v-card class="d-inline-block mx-auto" min-width="60vw" :width="isMobile && '100%'">
               <v-card-title>
                 口コミ評価
               </v-card-title>
@@ -99,7 +99,8 @@ export default {
       playerFlagMap: [
         'プレーヤー',
         '保護者'
-      ]
+      ],
+      isMobile: this.$vuetify.breakpoint.smAndDown
     }
   },
   computed: {

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -17,9 +17,10 @@
     > -->
       <v-list>
         <v-list-item
-          v-for="(item, i) in items"
+          v-for="(item, i) in !!token ? [...items, logoutItem] : [...items, ...loginItems]"
           :key="i"
           :to="item.to"
+          @click="item.onClick"
           router
           exact
         >
@@ -39,12 +40,13 @@
     >
       <!-- <v-app-bar-nav-icon @click.stop="drawer = !drawer" v-if="token" /> -->
       <v-app-bar-nav-icon @click.stop="drawer = !drawer" />
-      <v-toolbar-title v-text="title" @click="$router.push('/')" style="cursor: pointer" />
+      <v-toolbar-title v-if="isMobile" @click="$router.push('/top')" class="toolbar SP">{{title}}<font class="sub-title SP">{{subTitle}}</font></v-toolbar-title>
+      <v-toolbar-title v-else @click="$router.push('/top')" style="cursor: pointer">{{subTitle + ' - ' + title}}</v-toolbar-title>
       <v-spacer />
-      <common-button @click="logOut" v-if="!!token" button-color="warning">
+      <common-button @click="logOut" v-if="!!token && !isMobile" button-color="warning">
         ログアウト
       </common-button>
-      <common-button @click="$router.push('/login')" v-else button-color="primary">
+      <common-button @click="$router.push('/login')" v-else-if="!isMobile" button-color="primary">
         チームを登録するにはログインが必要です
       </common-button>
     </v-app-bar>
@@ -108,7 +110,9 @@ export default {
           icon: 'mdi-apps',
           title: 'エリアから探す',
           to: '/topPrefecture'
-        },
+        }
+      ],
+      loginItems: [
         {
           icon: 'mdi-chart-bubble',
           title: 'ログイン',
@@ -120,6 +124,11 @@ export default {
           to: '/signup'
         }
       ],
+      logoutItem: {
+        icon: 'mdi-chart-bubble',
+        title: 'ログアウト',
+        onClick: () => this.logOut()
+      },
       footerLinks: [
         {
           title: 'ホーム',
@@ -141,7 +150,9 @@ export default {
       miniVariant: false,
       right: true,
       rightDrawer: false,
-      title: '総合スポーツチーム口コミ情報サイト​ - SPOLEAD'
+      title: 'SPOLEAD',
+      subTitle: '総合スポーツチーム口コミ情報サイト',
+      isMobile: this.$vuetify.breakpoint.smAndDown
     }
   },
   computed: {
@@ -197,5 +208,20 @@ export default {
   .common-button {
     margin-right: 20px;
   }
+}
+.toolbar {
+  cursor: pointer;
+}
+.toolbar.SP {
+  padding: 0 !important;
+  overflow: unset;
+}
+.sub-title.SP {
+  font-size: 10px;
+  margin-left: 4px;
+}
+.login-buttons {
+  background: transparent;
+  width: 100%;
 }
 </style>

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -56,7 +56,6 @@
       </v-container>
     </v-content>
     <v-footer
-      :fixed="fixed"
       color="primary lighten-1"
       padless
       app
@@ -77,7 +76,7 @@
           {{ link.title }}
         </v-btn>
         <v-col
-          class="primary lighten-2 py-4 text-center white--text"
+          class="primary lighten-2 py-4 text-center white--text copyright"
           cols="12"
         >
           <span>&copy; Spolead.All rights reserved 2020 {{ nowYear }}</span>
@@ -223,5 +222,15 @@ export default {
 .login-buttons {
   background: transparent;
   width: 100%;
+}
+.v-footer {
+  position: unset;
+}
+.copyright {
+  overflow: unset;
+  width: 100vw;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+  font-size: 12px;
 }
 </style>

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -51,7 +51,7 @@
       </common-button>
     </v-app-bar>
     <v-content>
-      <v-container>
+      <v-container  v-resize="onResize" :class="isMobile && 'SP'">
         <nuxt />
       </v-container>
     </v-content>
@@ -195,6 +195,9 @@ export default {
       // }).catch((err) => {
       //   console.log('ERROR', err)
       // })
+    },
+    onResize () {
+      this.isMobile = this.$vuetify.breakpoint.smAndDown
     }
   }
 }

--- a/pages/Login.vue
+++ b/pages/Login.vue
@@ -7,7 +7,7 @@
     <div class="page-header">
       <div class="page-header-title">
         <common-button @click="goSignupPage" button-color="primary" button-size="large">
-          アカウントの新規作成
+          アカウント登録
         </common-button>
       </div>
     </div>
@@ -43,7 +43,7 @@
         <!-- mypass -->
       </v-form>
     </v-flex>
-    <common-button @click="login" button-size="large" button-color="primary" button-width="25vw">
+    <common-button @click="login" button-size="large" button-color="primary" class="login-button">
       ログイン
     </common-button>
     <v-alert v-if="invalidAuth" type="error">
@@ -136,13 +136,30 @@ export default {
   align-items: center;
   justify-content: center;
 }
+.SP .page-title {
+  width: 100%;
+  height: 13vh;
+  font-size: 32px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
 .page-content {
   margin: 32px;
 }
 .v-input {
   width: 25vw;
 }
+.SP .v-input {
+  width: 75vw;
+}
 .v-alert {
   margin: 32px;
+}
+.login-button {
+  width: 25vw;
+}
+.SP .login-button {
+  width: 75vw;
 }
 </style>

--- a/pages/Signup.vue
+++ b/pages/Signup.vue
@@ -12,7 +12,7 @@
       </div>
     </div>
     <div class="page-title">
-      ユーザー登録ページ
+      アカウント登録
     </div>
     <v-flex
       xs12
@@ -54,8 +54,8 @@
         />
       </v-form>
     </v-flex>
-    <common-button @click="signUp" button-size="large" button-color="primary" button-width="25vw">
-      ユーザー登録
+    <common-button @click="signUp" button-size="large" button-color="primary" class="signup-button">
+      アカウント登録
     </common-button>
   </v-layout>
 </template>
@@ -147,10 +147,22 @@ export default {
   align-items: center;
   justify-content: center;
 }
+.SP .page-title {
+  font-size: 32px;
+}
 .page-content {
   margin: 32px;
 }
 .v-input {
   width: 25vw;
+}
+.SP .v-input {
+  width: 75vw;
+}
+.signup-button {
+  width: 25vw;
+}
+.SP .signup-button {
+  width: 75vw;
 }
 </style>

--- a/pages/TeamDetails.vue
+++ b/pages/TeamDetails.vue
@@ -72,7 +72,7 @@
                   <v-row justify="space-between">
                     <v-col cols="auto">
                       <!-- <div class="grey--text">チームトップ情報</div> -->
-                      <p>{{ team.team_information }}</p>
+                      <p v-html="transformTextToHtml(team.team_information)" />
                     </v-col>
                   </v-row>
                 </v-container>
@@ -146,6 +146,7 @@ import CommonButton from '~/components/atoms/CommonButton.vue'
 import TeamEditModal from '~/components/organisms/TeamEditModal.vue'
 import ReviewsRegistModal from '~/components/organisms/ReviewsRegistModal.vue'
 import ReviewContent from '~/components/organisms/ReviewContent.vue'
+import transformTextToHtml from '~/pages/utils/transformTextToHtml'
 
 export default {
   components: {
@@ -157,6 +158,7 @@ export default {
   data () {
     return {
       colors,
+      transformTextToHtml,
       tab: null,
       rating: 3,
       valid: true,

--- a/pages/TeamDetails.vue
+++ b/pages/TeamDetails.vue
@@ -51,8 +51,8 @@
 
         <v-tabs-items v-model="tab">
           <v-tab-item>
-            <div class="page-content-item-main">
-              <div class="page-content-item-list">
+            <div :class="`page-content-item-main ${isMobile && 'SP'}`">
+              <div :class="`page-content-item-list ${isMobile && 'SP'}`">
                 <v-card class="d-inline-block mx-auto">
                   <v-container>
                     <v-row justify="space-between">
@@ -171,7 +171,8 @@ export default {
       team: {},
       reviewsList: [],
       sports_name: '',
-      showMoreInfo: true
+      showMoreInfo: true,
+      isMobile: this.$vuetify.breakpoint.smAndDown
     }
   },
   computed: {
@@ -308,14 +309,9 @@ export default {
 @import '~/assets/scss/page.scss';
 .page-header {
   @include default-page-header;
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  &-sub {
-    .common-button {
-      width: 10vw;
-    }
-  }
+}
+.page-header-sub {
+  text-align: right;
 }
 .page-content {
   @include default-page-content;
@@ -330,5 +326,12 @@ export default {
   .tabs {
     margin: 24px 0px;
   }
+}
+.page-content-item-main.SP {
+  flex-direction: column;
+}
+.page-content-item-list.SP {
+  display: flex;
+  justify-content: center;
 }
 </style>

--- a/pages/Teams.vue
+++ b/pages/Teams.vue
@@ -51,14 +51,14 @@
               <v-rating v-model="team.average_point" readonly />
             </div>
             <div class="page-content-item-lists">
-              {{ team.team_information }}
+              <p v-html="transformTextToHtml(team.team_information)" />
             </div>
             <v-divider :inset="false" class="inner-divider" />
             <div class="page-content-item-lists grey--text">
               最新の口コミ評価({{ getLatestReview(team.reviews) ? new Date(getLatestReview(team.reviews).updated_at).toLocaleString() : 'まだ口コミがありません' }})
             </div>
             <div v-if="getLatestReview(team.reviews)" class="page-content-item-lists mx-6">
-              {{ getLatestReview(team.reviews).general_post }}
+              <p v-html="transformTextToHtml(getLatestReview(team.reviews).general_post)" />
             </div>
           </div>
         </div>
@@ -84,6 +84,7 @@ import CommonButton from '~/components/atoms/CommonButton.vue'
 import TeamRegistModal from '~/components/organisms/TeamRegistModal.vue'
 import SearchForm from '~/components/molecules/SearchForm.vue'
 import Pagination from '~/components/molecules/Pagination.vue'
+import transformTextToHtml from '~/pages/utils/transformTextToHtml'
 
 export default {
   components: {
@@ -95,6 +96,7 @@ export default {
   data () {
     return {
       colors,
+      transformTextToHtml,
       valid: true,
       nickname: '',
       email: '',

--- a/pages/Teams.vue
+++ b/pages/Teams.vue
@@ -25,6 +25,8 @@
       <div class="page-content-item">
         <div class="page-content-item-header" style="display">
           {{ team.name }} ({{ team.prefecture }}{{ team.city }}{{ team.street_number }})
+          <v-chip color="primary" x-small>{{ teamTypeList[team.team_type] }}</v-chip>
+          <v-chip color="primary" x-small>{{ targetAgeList[team.target_age_type] }}</v-chip>
           <!-- <v-rating v-model="team.average_point" v-if="team.average_point" readonly /> -->
         </div>
         <div class="page-content-item-main">
@@ -106,7 +108,9 @@ export default {
       teams: [],
       searchWord: '',
       page: 1,
-      totalPages: 15
+      totalPages: 15,
+      targetAgeList: [null, 'キッズ', '小学生', '中学生', '高校生', '大学生'],
+      teamTypeList: [null, 'チーム', 'スクール']
     }
   },
   computed: {

--- a/pages/Teams.vue
+++ b/pages/Teams.vue
@@ -22,7 +22,7 @@
       flex-wrap
       class="page-content"
     >
-      <div class="page-content-item">
+      <div :class="`page-content-item ${isMobile && 'SP'}`">
         <div class="page-content-item-header" style="display">
           {{ team.name }} ({{ team.prefecture }}{{ team.city }}{{ team.street_number }})
           <v-chip color="primary" x-small>{{ teamTypeList[team.team_type] }}</v-chip>
@@ -236,5 +236,11 @@ export default {
   display: flex;
   flex-direction: column;
   align-items: center;
+}
+.page-content-item {
+  width: 100%;
+}
+.page-content-item.SP {
+  width: fit-content;
 }
 </style>

--- a/pages/Teams.vue
+++ b/pages/Teams.vue
@@ -6,12 +6,12 @@
   >
     <div class="page-header">
       チーム一覧
-      <div class="page-header-title">
-        <SearchForm @execSearch="execSearch" />
-      </div>
       <common-button @click="showRegistTeamModal" v-if="isLogin" button-color="primary">
         チームを登録する
       </common-button>
+    </div>
+    <div class="page-header-title">
+      <SearchForm :class="isMobile && 'SP'" @execSearch="execSearch" />
     </div>
     <v-flex
       v-for="team in teams"
@@ -29,7 +29,7 @@
           <v-chip color="primary" x-small>{{ targetAgeList[team.target_age_type] }}</v-chip>
           <!-- <v-rating v-model="team.average_point" v-if="team.average_point" readonly /> -->
         </div>
-        <div class="page-content-item-main">
+        <div :class="`${isMobile && 'flex'} page-content-item-main`">
           <div class="page-content-item-list">
             <v-card class="d-inline-block mx-auto">
               <v-container>
@@ -110,7 +110,8 @@ export default {
       page: 1,
       totalPages: 15,
       targetAgeList: [null, 'キッズ', '小学生', '中学生', '高校生', '大学生'],
-      teamTypeList: [null, 'チーム', 'スクール']
+      teamTypeList: [null, 'チーム', 'スクール'],
+      isMobile: this.$vuetify.breakpoint.smAndDown
     }
   },
   computed: {
@@ -227,5 +228,13 @@ export default {
 }
 .v-input {
   width: 25vw;
+}
+.search-field.SP {
+  width: 100%;
+}
+.flex {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
 }
 </style>

--- a/pages/TopPrefecture.vue
+++ b/pages/TopPrefecture.vue
@@ -6,9 +6,6 @@
   >
     <div class="page-header">
       <div class="page-header-title">
-        総合スポーツチーム口コミ情報サイト
-      </div>
-      <div class="page-header-title">
         <common-button @click="topSports" button-size="large" button-color="primary">
           スポーツから探す
         </common-button>
@@ -16,6 +13,9 @@
           ユーザー登録する
         </common-button>
       </div>
+    </div>
+    <div class="page-title">
+      総合スポーツチーム口コミ情報サイト
     </div>
     <v-img
       :src="require('~/assets/images/spolead-logo4.png')"
@@ -36,7 +36,7 @@
       <v-col
         v-for="card in cards"
         :key="card.title"
-        :cols="card.flex"
+        cols="3"
         @click="goPrefectureMode(card.id)"
         class="sports"
       >
@@ -290,17 +290,29 @@ export default {
 @import '~/assets/scss/page.scss';
 
 .page-header {
-  @include top-page-header
+  @include top-page-header;
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
 }
 .page-title {
   width: 100%;
-  height: 13vh;
-  font-size: 56px;
+  font-size: 32px;
   display: flex;
   align-items: center;
   justify-content: center;
 }
 .page-content {
   @include top-page-content
+}
+.SP .page-content {
+  margin: 0;
+  .sports {
+    flex: 0 0 100%;
+    max-width: 100%;
+  }
+}
+.logo {
+  margin-top: 20px;
 }
 </style>

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -16,9 +16,6 @@
   >
     <div class="page-header">
       <div class="page-header-title">
-         地域スポーツチーム・クラブ総合口コミポータル
-      </div>
-      <div class="page-header-title">
         <common-button @click="topPrefecture" button-size="large" button-color="primary">
           エリアから探す
         </common-button>
@@ -27,10 +24,14 @@
         </common-button>
       </div>
     </div>
+    <div class="page-title">
+         地域スポーツチーム・クラブ総合口コミポータル
+    </div>
     <v-img
       :src="require('~/assets/images/spolead-logo4.png')"
       :width="350"
       :aspect-ratio="16/6"
+      class="logo"
     />
     <v-flex
       xs12
@@ -43,7 +44,7 @@
       <v-col
         v-for="card in cards"
         :key="card.title"
-        :cols="card.flex"
+        :cols="3"
         @click="goTeamsPage(card.id)"
         class="sports"
       >
@@ -77,13 +78,13 @@ export default {
     return {
       token: '',
       cards: [
-        { id: 1, title: 'Soccer', src: require('~/assets/images/soccer.jpg'), flex: 3 },
-        { id: 2, title: 'Baseball', src: require('~/assets/images/baseball.jpg'), flex: 3 },
-        { id: 3, title: 'Basketball', src: require('~/assets/images/basketball.jpeg'), flex: 3 },
-        { id: 4, title: 'Volleyball', src: require('~/assets/images/volleyball.jpeg'), flex: 3 },
-        { id: 5, title: 'Dance', src: require('~/assets/images/dance.jpeg'), flex: 3 },
-        { id: 6, title: 'Rugby', src: require('~/assets/images/rugby.jpeg'), flex: 3 },
-        { id: 7, title: 'Swimming', src: require('~/assets/images/swimming.jpeg'), flex: 3 }
+        { id: 1, title: 'Soccer', src: require('~/assets/images/soccer.jpg') },
+        { id: 2, title: 'Baseball', src: require('~/assets/images/baseball.jpg') },
+        { id: 3, title: 'Basketball', src: require('~/assets/images/basketball.jpeg') },
+        { id: 4, title: 'Volleyball', src: require('~/assets/images/volleyball.jpeg') },
+        { id: 5, title: 'Dance', src: require('~/assets/images/dance.jpeg') },
+        { id: 6, title: 'Rugby', src: require('~/assets/images/rugby.jpeg') },
+        { id: 7, title: 'Swimming', src: require('~/assets/images/swimming.jpeg') }
       ]
     }
   },
@@ -116,12 +117,14 @@ export default {
 @import '~/assets/scss/page.scss';
 
 .page-header {
-  @include top-page-header
+  @include default-page-header;
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
 }
 .page-title {
   width: 100%;
-  height: 13vh;
-  font-size: 56px;
+  font-size: 32px;
   display: flex;
   align-items: center;
   justify-content: center;
@@ -131,5 +134,12 @@ export default {
   .sports {
     cursor: pointer;
   }
+}
+.SP .page-content .sports {
+  flex: 0 0 100%;
+  max-width: 100%;
+}
+.logo {
+  margin-top: 20px;
 }
 </style>

--- a/pages/utils/transformTextToHtml.js
+++ b/pages/utils/transformTextToHtml.js
@@ -1,0 +1,3 @@
+export default function transformTextToHtml (text) {
+  return '<span>' + text.replace(/\n/g, ' <br/>').replace(/(https?:\/\/[^\s]*)/g, "<a href='$1'>$1</a>") + '</span>'
+}


### PR DESCRIPTION
# 概要

レスポンシブ対応
テキストの変換
   - 改行の反映
   - https~の文字列をリンク判定
   - fontタグ等のhtmlをテキストに変換
表示項目追加
   - チーム一覧でチームタイプと対象年齢を表示

# 動作確認方法
### レスポンシブ化
1. ChromeDevToolsのElementタブからデバイスモードをオンにする
2. 画面幅を959px以下にする（場合によってはリロードが必要）

### テキストの変換
1. チーム登録 or 口コミ投稿をする
2. 以下のテキストを含めて登録 or 投稿する

```
▼ 改行が反映されていることの確認
サンプルテキスト
改行
サンプルテキスト

▼ フォントのカスタマイズが反映されていることの確認
<font color="red">赤文字になっている</font>

▼ URLがリンクになっていることの確認
https://spolead.com/
https://spolead.com/Teams
```

### 表示項目追加
1. チーム一覧を表示

# 補足
進捗状態 / 懸念点に関しては、[こちらのスプレッドシート](https://docs.google.com/spreadsheets/d/1Ya5hShDul_fBItyQr8tyrl3K6nG35KU2WfqN8IkVz54/edit#gid=0)を参照してください。